### PR TITLE
Fixed Hex Color format when Legacy Hex Color option is off

### DIFF
--- a/src/main/java/net/noscape/project/supremetags/utils/Utils.java
+++ b/src/main/java/net/noscape/project/supremetags/utils/Utils.java
@@ -53,7 +53,7 @@ public class Utils {
                 Matcher matcher = p3.matcher(message);
                 StringBuffer sb = new StringBuffer();
                 while (matcher.find()) {
-                    ChatColor hexColor = ChatColor.of(matcher.group().substring(1));
+                    ChatColor hexColor = ChatColor.of(matcher.group().substring(0));
                     matcher.appendReplacement(sb, hexColor.toString());
                 }
                 matcher.appendTail(sb);


### PR DESCRIPTION
# Current setup
Paper server on Paper 318 (MC Version: 1.20.2)
Java Version: Temurin-17.0.7+7

# Description

When turning off Legacy Color Option in the config and trying to use regular hex codes ( #9A5cc6 ) for the tags, the GUI crashes, complaining that the ChatColor couldn’t be parsed in.

The bug was really clear in the console, where the hashtag was not being parsed in (only the numbers of the provided hex code), causing it to crash. There needs to be a hashtag before the numbers or the method of ChatColor will throw an error.

# Reproducing the bug
Turn off Legacy Hex Color from the config.
Use normal hex colors for tags
Turn on the server
Use the /tag command to attempt to open the GUI. An error will occur complaining that the hex code is incorrect from the terminal
